### PR TITLE
Support building EL8 on EL7

### DIFF
--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -30,6 +30,7 @@ srpm: build_prepare
 	/usr/bin/mock \
 		--no-cleanup-after \
 		-r $(MOCK_CONFIG) \
+		--bootstrap-chroot \
 		--define "__version $(VERSION)$(VERSION_SUFFIX)" \
 		--define "__release $(BUILD_NUMBER)" \
 		--resultdir=$(RESULT_DIR) \
@@ -42,6 +43,7 @@ rpm: srpm
 	/usr/bin/mock \
 		--no-cleanup-after \
 		-r $(MOCK_CONFIG) \
+		--bootstrap-chroot \
 		--define "__version $(VERSION)$(VERSION_SUFFIX)"\
 		--define "__release $(BUILD_NUMBER)"\
 		--resultdir=$(RESULT_DIR) \


### PR DESCRIPTION
To summarize we encounter this issue: https://github.com/rpm-software-management/mock/wiki/FAQ#i-cannot-build-fedora-or-rhel8-beta-package-on-rhelcentos-7

When trying to build EL8 packages on EL7 (Our CentOS-7 package builder). Adding this switch allows mock to self bootstrap an EL8 mock chroot to install EL8 packages. 

I tested this out on our CentOS-7 builder, but it seems to be failing in the EL8 environment (But builds in EL7 - maybe `boost` related?). 

```
make[2]: Leaving directory '/builddir/build/BUILD/avro-cpp-1.8.0'
make[2]: *** [CMakeFiles/SchemaTests.dir/build.make:66: CMakeFiles/SchemaTests.dir/test/SchemaTests.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:230: CMakeFiles/SchemaTests.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[ 63%] Linking CXX executable DataFileTests
/usr/bin/cmake -E cmake_link_script CMakeFiles/DataFileTests.dir/link.txt --verbose=1
/usr/bin/c++  -Wall -DNDEBUG  -Wl,-z,relro  -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -rdynamic CMakeFiles/DataFileTests.dir/test/DataFileTests.cc.o  -o DataFileTests -Wl,-rpath,/builddir/build/BUILD/avro-cpp-1.8.0 libavrocpp.so.1.8.0.0 -lboost_filesystem -lboost_system -lboost_program_options -lboost_iostreams -lboost_regex
/usr/bin/ld: CMakeFiles/DataFileTests.dir/test/DataFileTests.cc.o: relocation R_X86_64_32 against `.rodata' can not be used when making a PIE object; recompile with -fPIC
/usr/bin/ld: final link failed: Nonrepresentable section on output
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/DataFileTests.dir/build.make:93: DataFileTests] Error 1
make[2]: Leaving directory '/builddir/build/BUILD/avro-cpp-1.8.0'
make[1]: *** [CMakeFiles/Makefile2:156: CMakeFiles/DataFileTests.dir/all] Error 2
[ 65%] Linking CXX executable CodecTests
```

That will probably be fixed in parallel to this change.