### PR TITLE
Add override option to rpm make

### DIFF
--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -28,6 +28,7 @@ build_prepare: archive
 
 srpm: build_prepare
 	/usr/bin/mock \
+		$(MOCK_OPTIONS) \
 		--no-cleanup-after \
 		-r $(MOCK_CONFIG) \
 		--define "__version $(VERSION)$(VERSION_SUFFIX)" \
@@ -40,6 +41,7 @@ srpm: build_prepare
 
 rpm: srpm
 	/usr/bin/mock \
+		$(MOCK_OPTIONS) \
 		--no-cleanup-after \
 		-r $(MOCK_CONFIG) \
 		--define "__version $(VERSION)$(VERSION_SUFFIX)"\

--- a/rpm/README
+++ b/rpm/README
@@ -9,3 +9,8 @@ Build:
 
    MOCK_CONFIG=fedora-20-x86_64 make
 
+Additional Mock Options:
+
+    # Say you wanted to build an RPM targeting a distro with rpm>4.12.x with rpm<4.12.x
+    MOCK_OPTIONS=--bootstrap-chroot MOCK_CONFIG=fedora-30-x86_64 make
+


### PR DESCRIPTION
Better version of https://github.com/confluentinc/avro-cpp-packaging/pull/5

Without specifying it:
```
[root@ip-172-31-35-84 rpm]# make MOCK_CONFIG=epel-8-x86_64
cd ../ && \
git archive --prefix=avro-cpp-1.8.0/ \
  -o rpm/SOURCES/avro-cpp-1.8.0.tar.gz HEAD
cp *.patch SOURCES
mkdir -p pkgs-1.8.0-1-epel-8-x86_64
rm -f pkgs-1.8.0-1-epel-8-x86_64/avro-cpp*.rpm
/usr/bin/mock \
	 \
	--no-cleanup-after \
	-r epel-8-x86_64 \
	--define "__version 1.8.0" \
	--define "__release 1" \
	--resultdir=pkgs-1.8.0-1-epel-8-x86_64 \
	--buildsrpm \
	--spec=avro-cpp.spec \
	--sources=SOURCES
INFO: mock.py version 1.4.21 starting (python version = 3.6.8)...
...
Running transaction test
Transaction test succeeded
Running transaction


Invalid version flag: if

make: *** [rpm] Error 30
```

With specifying it (note: building epel-7 since there seems to be an EL8 issue):

```
[root@ip-172-31-35-84 rpm]# make MOCK_CONFIG=epel-7-x86_64 MOCK_OPTIONS=--bootstrap-chroot
mkdir -p SOURCES
cd ../ && \
git archive --prefix=avro-cpp-1.8.0/ \
  -o rpm/SOURCES/avro-cpp-1.8.0.tar.gz HEAD
cp *.patch SOURCES
mkdir -p pkgs-1.8.0-1-epel-7-x86_64
rm -f pkgs-1.8.0-1-epel-7-x86_64/avro-cpp*.rpm
/usr/bin/mock \
	--bootstrap-chroot \
	--no-cleanup-after \
	-r epel-7-x86_64 \
	--define "__version 1.8.0" \
	--define "__release 1" \
	--resultdir=pkgs-1.8.0-1-epel-7-x86_64 \
	--buildsrpm \
	--spec=avro-cpp.spec \
	--sources=SOURCES
INFO: mock.py version 1.4.21 starting (python version = 3.6.8)...
...
Checking for unpackaged file(s): /usr/lib/rpm/check-files /builddir/build/BUILDROOT/avro-cpp-1.8.0-1.el7.x86_64
Wrote: /builddir/build/RPMS/avro-cpp-1.8.0-1.el7.x86_64.rpm
Wrote: /builddir/build/RPMS/avro-cpp-devel-1.8.0-1.el7.x86_64.rpm
Wrote: /builddir/build/RPMS/avro-cpp-debuginfo-1.8.0-1.el7.x86_64.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.mOdscl
+ umask 022
+ cd /builddir/build/BUILD
+ cd avro-cpp-1.8.0
+ rm -rf /builddir/build/BUILDROOT/avro-cpp-1.8.0-1.el7.x86_64
+ exit 0
Finish: rpmbuild avro-cpp-1.8.0-1.el7.src.rpm
Finish: build phase for avro-cpp-1.8.0-1.el7.src.rpm
INFO: Done(pkgs-1.8.0-1-epel-7-x86_64/avro-cpp-1.8.0-1.el7.src.rpm) Config(epel-7-x86_64) 1 minutes 27 seconds
INFO: Results and/or logs in: pkgs-1.8.0-1-epel-7-x86_64
Finish: run
======= Binary RPMs now available in pkgs-1.8.0-1-epel-7-x86_64 =======
```

However the build fails on an un-related issue on EL8, builds fine on EL7