### PR TITLE
Rpm support el8 build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ add_definitions (
     -DBOOST_PROGRAM_OPTIONS_DYN_LINK
     -DBOOST_ALL_NO_LIB)
 else()
-    add_definitions(-fPIC -g)
+    add_definitions(-fPIC -g -O2)
 endif()
 
 if (CMAKE_COMPILER_IS_GNUCXX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ add_definitions (
     -DBOOST_PROGRAM_OPTIONS_DYN_LINK
     -DBOOST_ALL_NO_LIB)
 else()
-    add_definitions(-std=c++11 -fPIC -g)
+    add_definitions(-fPIC -g)
 endif()
 
 if (CMAKE_COMPILER_IS_GNUCXX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#   https://www.apache.org/licenses/LICENSE-2.0
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -20,8 +20,6 @@ cmake_minimum_required (VERSION 2.6)
 
 set (CMAKE_LEGACY_CYGWIN_WIN32 0)
 
-cmake_policy (SET CMP0042 NEW)
-
 if (NOT DEFINED CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_NO_WARNINGS)
     set (CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_NO_WARNINGS ON)
 endif()
@@ -33,60 +31,38 @@ else (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/VERSION.txt)
         AVRO_VERSION)
 endif (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/VERSION.txt)
 
-string(REPLACE "\n" "" AVRO_VERSION  ${AVRO_VERSION})
 set (AVRO_VERSION_MAJOR ${AVRO_VERSION})
 set (AVRO_VERSION_MINOR "0")
 
 project (Avro-cpp)
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR})
 
 if (WIN32 AND NOT CYGWIN AND NOT MSYS)
-    add_definitions (/EHa)
-    add_definitions (
-        -DNOMINMAX
-        -DBOOST_REGEX_DYN_LINK
-        -DBOOST_FILESYSTEM_DYN_LINK
-        -DBOOST_SYSTEM_DYN_LINK
-        -DBOOST_IOSTREAMS_DYN_LINK
-        -DBOOST_PROGRAM_OPTIONS_DYN_LINK
-        -DBOOST_ALL_NO_LIB)
+add_definitions (/EHa)
+add_definitions (
+    -DBOOST_REGEX_DYN_LINK
+    -DBOOST_FILESYSTEM_DYN_LINK
+    -DBOOST_SYSTEM_DYN_LINK
+    -DBOOST_IOSTREAMS_DYN_LINK
+    -DBOOST_PROGRAM_OPTIONS_DYN_LINK
+    -DBOOST_ALL_NO_LIB)
 else()
-# Replease c++11 with c++17 below in case C++ 17 should be used
     add_definitions(-std=c++11 -fPIC)
 endif()
 
 if (CMAKE_COMPILER_IS_GNUCXX)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
-if (AVRO_ADD_PROTECTOR_FLAGS)
-    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fstack-protector-all -D_GLIBCXX_DEBUG")
-    # Unset _GLIBCXX_DEBUG for avrogencpp.cc because using Boost Program Options
-    # leads to linking errors when compiling with _GLIBCXX_DEBUG as described on
-    # https://stackoverflow.com/questions/19729036/
-    set_source_files_properties(impl/avrogencpp.cc PROPERTIES COMPILE_FLAGS "-U_GLIBCXX_DEBUG")
-endif ()
+    set(CMAKE_CXX_FLAGS "-Wall")
 endif ()
 
 
 find_package (Boost 1.38 REQUIRED
-    COMPONENTS filesystem iostreams program_options regex system)
-
-find_package(Snappy)
-if (SNAPPY_FOUND)
-    set(SNAPPY_PKG libsnappy)
-    add_definitions(-DSNAPPY_CODEC_AVAILABLE)
-    message("Enabled snappy codec")
-else (SNAPPY_FOUND)
-    set(SNAPPY_PKG "")
-    set(SNAPPY_LIBRARIES "")
-    message("Disabled snappy codec. libsnappy not found.")
-endif (SNAPPY_FOUND)
+    COMPONENTS filesystem system program_options iostreams)
 
 add_definitions (${Boost_LIB_DIAGNOSTIC_DEFINITIONS})
 
 include_directories (api ${CMAKE_CURRENT_BINARY_DIR} ${Boost_INCLUDE_DIRS})
 
 set (AVRO_SOURCE_FILES
-        impl/Compiler.cc impl/Node.cc impl/LogicalType.cc
+        impl/Compiler.cc impl/Node.cc
         impl/NodeImpl.cc impl/ResolverSchema.cc impl/Schema.cc
         impl/Types.cc impl/ValidSchema.cc impl/Zigzag.cc
         impl/BinaryEncoder.cc impl/BinaryDecoder.cc
@@ -118,11 +94,11 @@ set_target_properties (avrocpp PROPERTIES
 set_target_properties (avrocpp_s PROPERTIES
     VERSION ${AVRO_VERSION_MAJOR}.${AVRO_VERSION_MINOR})
 
-target_link_libraries (avrocpp ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES})
+target_link_libraries (avrocpp ${Boost_LIBRARIES})
 
 add_executable (precompile test/precompile.cc)
 
-target_link_libraries (precompile avrocpp_s ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES})
+target_link_libraries (precompile avrocpp_s ${Boost_LIBRARIES})
 
 macro (gen file ns)
     add_custom_command (OUTPUT ${file}.hh
@@ -145,19 +121,15 @@ gen (union_conflict uc)
 gen (recursive rec)
 gen (reuse ru)
 gen (circulardep cd)
-gen (tree1 tr1)
-gen (tree2 tr2)
-gen (crossref cr)
-gen (primitivetypes pt)
 
 add_executable (avrogencpp impl/avrogencpp.cc)
-target_link_libraries (avrogencpp avrocpp_s ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES})
+target_link_libraries (avrogencpp avrocpp_s ${Boost_LIBRARIES})
 
 enable_testing()
 
 macro (unittest name)
     add_executable (${name} test/${name}.cc)
-    target_link_libraries (${name} avrocpp ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES})
+    target_link_libraries (${name} avrocpp ${Boost_LIBRARIES})
     add_test (NAME ${name} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${name})
 endmacro (unittest)
@@ -172,13 +144,11 @@ unittest (SpecificTests)
 unittest (DataFileTests)
 unittest (JsonTests)
 unittest (AvrogencppTests)
-unittest (CompilerTests)
 
 add_dependencies (AvrogencppTests bigrecord_hh bigrecord_r_hh bigrecord2_hh
     tweet_hh
     union_array_union_hh union_map_union_hh union_conflict_hh
-    recursive_hh reuse_hh circulardep_hh tree1_hh tree2_hh crossref_hh
-    primitivetypes_hh empty_record_hh)
+    recursive_hh reuse_hh circulardep_hh empty_record_hh)
 
 include (InstallRequiredSystemLibraries)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -20,6 +20,8 @@ cmake_minimum_required (VERSION 2.6)
 
 set (CMAKE_LEGACY_CYGWIN_WIN32 0)
 
+cmake_policy (SET CMP0042 NEW)
+
 if (NOT DEFINED CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_NO_WARNINGS)
     set (CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_NO_WARNINGS ON)
 endif()
@@ -31,36 +33,60 @@ else (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/VERSION.txt)
         AVRO_VERSION)
 endif (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/VERSION.txt)
 
+string(REPLACE "\n" "" AVRO_VERSION  ${AVRO_VERSION})
 set (AVRO_VERSION_MAJOR ${AVRO_VERSION})
 set (AVRO_VERSION_MINOR "0")
 
 project (Avro-cpp)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR})
 
 if (WIN32 AND NOT CYGWIN AND NOT MSYS)
-add_definitions (/EHa)
-add_definitions (
-    -DBOOST_REGEX_DYN_LINK
-    -DBOOST_FILESYSTEM_DYN_LINK
-    -DBOOST_SYSTEM_DYN_LINK
-    -DBOOST_IOSTREAMS_DYN_LINK
-    -DBOOST_PROGRAM_OPTIONS_DYN_LINK
-    -DBOOST_ALL_NO_LIB)
+    add_definitions (/EHa)
+    add_definitions (
+        -DNOMINMAX
+        -DBOOST_REGEX_DYN_LINK
+        -DBOOST_FILESYSTEM_DYN_LINK
+        -DBOOST_SYSTEM_DYN_LINK
+        -DBOOST_IOSTREAMS_DYN_LINK
+        -DBOOST_PROGRAM_OPTIONS_DYN_LINK
+        -DBOOST_ALL_NO_LIB)
+else()
+# Replease c++11 with c++17 below in case C++ 17 should be used
+    add_definitions(-std=c++11 -fPIC)
 endif()
 
 if (CMAKE_COMPILER_IS_GNUCXX)
-    set(CMAKE_CXX_FLAGS "-Wall -fPIC")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+if (AVRO_ADD_PROTECTOR_FLAGS)
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fstack-protector-all -D_GLIBCXX_DEBUG")
+    # Unset _GLIBCXX_DEBUG for avrogencpp.cc because using Boost Program Options
+    # leads to linking errors when compiling with _GLIBCXX_DEBUG as described on
+    # https://stackoverflow.com/questions/19729036/
+    set_source_files_properties(impl/avrogencpp.cc PROPERTIES COMPILE_FLAGS "-U_GLIBCXX_DEBUG")
+endif ()
 endif ()
 
 
 find_package (Boost 1.38 REQUIRED
-    COMPONENTS filesystem system program_options iostreams)
+    COMPONENTS filesystem iostreams program_options regex system)
+
+find_package(Snappy)
+if (SNAPPY_FOUND)
+    set(SNAPPY_PKG libsnappy)
+    add_definitions(-DSNAPPY_CODEC_AVAILABLE)
+    message("Enabled snappy codec")
+else (SNAPPY_FOUND)
+    set(SNAPPY_PKG "")
+    set(SNAPPY_LIBRARIES "")
+    message("Disabled snappy codec. libsnappy not found.")
+endif (SNAPPY_FOUND)
 
 add_definitions (${Boost_LIB_DIAGNOSTIC_DEFINITIONS})
 
 include_directories (api ${CMAKE_CURRENT_BINARY_DIR} ${Boost_INCLUDE_DIRS})
 
 set (AVRO_SOURCE_FILES
-        impl/Compiler.cc impl/Node.cc
+        impl/Compiler.cc impl/Node.cc impl/LogicalType.cc
         impl/NodeImpl.cc impl/ResolverSchema.cc impl/Schema.cc
         impl/Types.cc impl/ValidSchema.cc impl/Zigzag.cc
         impl/BinaryEncoder.cc impl/BinaryDecoder.cc
@@ -92,11 +118,11 @@ set_target_properties (avrocpp PROPERTIES
 set_target_properties (avrocpp_s PROPERTIES
     VERSION ${AVRO_VERSION_MAJOR}.${AVRO_VERSION_MINOR})
 
-target_link_libraries (avrocpp ${Boost_LIBRARIES})
+target_link_libraries (avrocpp ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES})
 
 add_executable (precompile test/precompile.cc)
 
-target_link_libraries (precompile avrocpp_s ${Boost_LIBRARIES})
+target_link_libraries (precompile avrocpp_s ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES})
 
 macro (gen file ns)
     add_custom_command (OUTPUT ${file}.hh
@@ -119,15 +145,19 @@ gen (union_conflict uc)
 gen (recursive rec)
 gen (reuse ru)
 gen (circulardep cd)
+gen (tree1 tr1)
+gen (tree2 tr2)
+gen (crossref cr)
+gen (primitivetypes pt)
 
 add_executable (avrogencpp impl/avrogencpp.cc)
-target_link_libraries (avrogencpp avrocpp_s ${Boost_LIBRARIES})
+target_link_libraries (avrogencpp avrocpp_s ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES})
 
 enable_testing()
 
 macro (unittest name)
     add_executable (${name} test/${name}.cc)
-    target_link_libraries (${name} avrocpp ${Boost_LIBRARIES})
+    target_link_libraries (${name} avrocpp ${Boost_LIBRARIES} ${SNAPPY_LIBRARIES})
     add_test (NAME ${name} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${name})
 endmacro (unittest)
@@ -142,11 +172,13 @@ unittest (SpecificTests)
 unittest (DataFileTests)
 unittest (JsonTests)
 unittest (AvrogencppTests)
+unittest (CompilerTests)
 
 add_dependencies (AvrogencppTests bigrecord_hh bigrecord_r_hh bigrecord2_hh
     tweet_hh
     union_array_union_hh union_map_union_hh union_conflict_hh
-    recursive_hh reuse_hh circulardep_hh empty_record_hh)
+    recursive_hh reuse_hh circulardep_hh tree1_hh tree2_hh crossref_hh
+    primitivetypes_hh empty_record_hh)
 
 include (InstallRequiredSystemLibraries)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ add_definitions (
     -DBOOST_PROGRAM_OPTIONS_DYN_LINK
     -DBOOST_ALL_NO_LIB)
 else()
-    add_definitions(-std=c++11 -fPIC)
+    add_definitions(-std=c++11 -fPIC -g)
 endif()
 
 if (CMAKE_COMPILER_IS_GNUCXX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ add_definitions (
 endif()
 
 if (CMAKE_COMPILER_IS_GNUCXX)
-    set(CMAKE_CXX_FLAGS "-Wall")
+    set(CMAKE_CXX_FLAGS "-Wall -fPIC")
 endif ()
 
 

--- a/test/SchemaTests.cc
+++ b/test/SchemaTests.cc
@@ -138,19 +138,19 @@ const char* basicSchemaErrors[] = {
 
 static void testBasic(const char* schema)
 {
-    BOOST_CHECKPOINT(schema);
+    BOOST_TEST_CHECKPOINT(schema);
     compileJsonSchemaFromString(schema);
 }
 
 static void testBasic_fail(const char* schema)
 {
-    BOOST_CHECKPOINT(schema);
+    BOOST_TEST_CHECKPOINT(schema);
     BOOST_CHECK_THROW(compileJsonSchemaFromString(schema), Exception);
 }
 
 static void testCompile(const char* schema)
 {
-    BOOST_CHECKPOINT(schema);
+    BOOST_TEST_CHECKPOINT(schema);
     compileJsonSchemaFromString(std::string(schema));
 }
 

--- a/test/buffertest.cc
+++ b/test/buffertest.cc
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,7 +20,6 @@
 
 #include <boost/thread.hpp>
 #include <boost/bind.hpp>
-#include <boost/scoped_array.hpp>
 
 #ifdef HAVE_BOOST_ASIO
 #include <boost/asio.hpp>
@@ -64,7 +63,7 @@ void printBuffer(const InputBuffer &buf)
 
 void TestReserve()
 {
-    BOOST_WARN_MESSAGE( "TestReserve");
+    BOOST_TEST_MESSAGE( "TestReserve");
     {
         OutputBuffer ob;
         BOOST_CHECK_EQUAL(ob.size(), 0U);
@@ -111,7 +110,7 @@ void addDataToBuffer(OutputBuffer &buf, size_t size)
 
 void TestGrow()
 {
-    BOOST_WARN_MESSAGE( "TestGrow");
+    BOOST_TEST_MESSAGE( "TestGrow");
     { 
         OutputBuffer ob;
 
@@ -151,7 +150,7 @@ void TestGrow()
 
 void TestDiscard()
 {
-    BOOST_WARN_MESSAGE( "TestDiscard");
+    BOOST_TEST_MESSAGE( "TestDiscard");
     {
         OutputBuffer ob;
         size_t dataSize = kDefaultBlockSize*2 + kDefaultBlockSize/2;
@@ -257,7 +256,7 @@ void TestDiscard()
 
 void TestConvertToInput()
 {
-    BOOST_WARN_MESSAGE( "TestConvertToInput");
+    BOOST_TEST_MESSAGE( "TestConvertToInput");
     {
         OutputBuffer ob;
         size_t dataSize = kDefaultBlockSize*2 + kDefaultBlockSize/2;
@@ -277,7 +276,7 @@ void TestConvertToInput()
 
 void TestExtractToInput()
 {
-    BOOST_WARN_MESSAGE( "TestExtractToInput");
+    BOOST_TEST_MESSAGE( "TestExtractToInput");
     {
         OutputBuffer ob;
         size_t dataSize = kDefaultBlockSize*2 + kDefaultBlockSize/2;
@@ -376,7 +375,7 @@ void TestExtractToInput()
 
 void TestAppend()
 {
-    BOOST_WARN_MESSAGE( "TestAppend");
+    BOOST_TEST_MESSAGE( "TestAppend");
     {
         OutputBuffer ob;
         size_t dataSize = kDefaultBlockSize + kDefaultBlockSize/2;
@@ -405,7 +404,7 @@ void TestAppend()
 
 void TestBufferStream()
 {
-    BOOST_WARN_MESSAGE( "TestBufferStream");
+    BOOST_TEST_MESSAGE( "TestBufferStream");
 
     {
         // write enough bytes to a buffer, to create at least 3 blocks
@@ -456,7 +455,7 @@ void TestEof()
 
 void TestBufferStreamEof()
 {
-    BOOST_WARN_MESSAGE( "TestBufferStreamEof");
+    BOOST_TEST_MESSAGE( "TestBufferStreamEof");
 
     TestEof<int32_t>();
 
@@ -469,7 +468,7 @@ void TestBufferStreamEof()
 
 void TestSeekAndTell()
 {
-    BOOST_WARN_MESSAGE( "TestSeekAndTell");
+    BOOST_TEST_MESSAGE( "TestSeekAndTell");
 
     {
         std::string junk = makeString(kDefaultBlockSize/2);
@@ -501,7 +500,7 @@ void TestSeekAndTell()
 
 void TestReadSome()
 {
-    BOOST_WARN_MESSAGE( "TestReadSome");
+    BOOST_TEST_MESSAGE( "TestReadSome");
     {
         std::string junk = makeString(kDefaultBlockSize/2);
 
@@ -531,7 +530,7 @@ void TestReadSome()
 
 void TestSeek()
 {
-    BOOST_WARN_MESSAGE( "TestSeek");
+    BOOST_TEST_MESSAGE( "TestSeek");
     {
         const std::string str = "SampleMessage";
 
@@ -592,7 +591,7 @@ void TestSeek()
 
 void TestIterator() 
 {
-    BOOST_WARN_MESSAGE( "TestIterator");
+    BOOST_TEST_MESSAGE( "TestIterator");
     {
         OutputBuffer ob(2 * kMaxBlockSize + 10);
         BOOST_CHECK_EQUAL(ob.numChunks(), 3);
@@ -674,7 +673,7 @@ void server(boost::barrier &b)
 void TestAsioBuffer()
 {
     using boost::asio::ip::tcp;
-    BOOST_WARN_MESSAGE( "TestAsioBuffer");
+    BOOST_TEST_MESSAGE( "TestAsioBuffer");
     {
         boost::barrier b(2);
 
@@ -746,7 +745,7 @@ void TestAsioBuffer()
 
 void TestSplit()
 {
-    BOOST_WARN_MESSAGE( "TestSplit");
+    BOOST_TEST_MESSAGE( "TestSplit");
     {
         const std::string str = "This message is to be split";
 
@@ -773,7 +772,7 @@ void TestSplit()
 
 void TestSplitOnBorder()
 {
-    BOOST_WARN_MESSAGE( "TestSplitOnBorder");
+    BOOST_TEST_MESSAGE( "TestSplitOnBorder");
     {
 
         const std::string part1 = "This message";
@@ -793,7 +792,7 @@ void TestSplitOnBorder()
         BOOST_CHECK_EQUAL(buf.numDataChunks(), 2);
         size_t bufsize = buf.size();
     
-        boost::scoped_array<char> datain(new char[firstChunkSize]);
+        std::unique_ptr<char[]> datain(new char[firstChunkSize]);
         avro::istream is(buf);
         size_t in = static_cast<size_t>(is.readsome(&datain[0], firstChunkSize));
         BOOST_CHECK_EQUAL(in, firstChunkSize);
@@ -812,7 +811,7 @@ void TestSplitOnBorder()
 
 void TestSplitTwice() 
 {
-    BOOST_WARN_MESSAGE( "TestSplitTwice");
+    BOOST_TEST_MESSAGE( "TestSplitTwice");
     {
         const std::string msg1 = makeString(30);
 
@@ -842,7 +841,7 @@ void TestSplitTwice()
 
 void TestCopy() 
 {
-    BOOST_WARN_MESSAGE( "TestCopy");
+    BOOST_TEST_MESSAGE( "TestCopy");
 
     const std::string msg = makeString(30);
     // Test1, small data, small buffer
@@ -998,7 +997,7 @@ void TestCopy()
 // this is reproducing a sequence of steps that caused a crash
 void TestBug()  
 {
-    BOOST_WARN_MESSAGE( "TestBug");
+    BOOST_TEST_MESSAGE( "TestBug");
     {
         OutputBuffer rxBuf;
         OutputBuffer  buf;
@@ -1038,7 +1037,7 @@ void deleteForeign(const std::string &val)
 
 void TestForeign ()  
 {
-    BOOST_WARN_MESSAGE( "TestForeign");
+    BOOST_TEST_MESSAGE( "TestForeign");
     {
         std::string hello = "hello ";
         std::string there = "there ";
@@ -1065,7 +1064,7 @@ void TestForeign ()
 
 void TestForeignDiscard ()  
 {
-    BOOST_WARN_MESSAGE( "TestForeign");
+    BOOST_TEST_MESSAGE( "TestForeign");
     {
         std::string hello = "hello ";
         std::string again = "again ";
@@ -1104,7 +1103,7 @@ void TestForeignDiscard ()
 
 void TestPrinter()
 {
-    BOOST_WARN_MESSAGE( "TestPrinter");
+    BOOST_TEST_MESSAGE( "TestPrinter");
     {
         OutputBuffer ob;
         addDataToBuffer(ob, 128);

--- a/test/buffertest.cc
+++ b/test/buffertest.cc
@@ -20,6 +20,7 @@
 
 #include <boost/thread.hpp>
 #include <boost/bind.hpp>
+#include <boost/scoped_array.hpp>
 
 #ifdef HAVE_BOOST_ASIO
 #include <boost/asio.hpp>
@@ -792,7 +793,7 @@ void TestSplitOnBorder()
         BOOST_CHECK_EQUAL(buf.numDataChunks(), 2);
         size_t bufsize = buf.size();
     
-        std::unique_ptr<char[]> datain(new char[firstChunkSize]);
+        boost::scoped_array<char> datain(new char[firstChunkSize]);
         avro::istream is(buf);
         size_t in = static_cast<size_t>(is.readsome(&datain[0], firstChunkSize));
         BOOST_CHECK_EQUAL(in, firstChunkSize);

--- a/test/buffertest.cc
+++ b/test/buffertest.cc
@@ -64,7 +64,7 @@ void printBuffer(const InputBuffer &buf)
 
 void TestReserve()
 {
-    BOOST_MESSAGE( "TestReserve");
+    BOOST_WARN_MESSAGE( "TestReserve");
     {
         OutputBuffer ob;
         BOOST_CHECK_EQUAL(ob.size(), 0U);
@@ -111,7 +111,7 @@ void addDataToBuffer(OutputBuffer &buf, size_t size)
 
 void TestGrow()
 {
-    BOOST_MESSAGE( "TestGrow");
+    BOOST_WARN_MESSAGE( "TestGrow");
     { 
         OutputBuffer ob;
 
@@ -151,7 +151,7 @@ void TestGrow()
 
 void TestDiscard()
 {
-    BOOST_MESSAGE( "TestDiscard");
+    BOOST_WARN_MESSAGE( "TestDiscard");
     {
         OutputBuffer ob;
         size_t dataSize = kDefaultBlockSize*2 + kDefaultBlockSize/2;
@@ -257,7 +257,7 @@ void TestDiscard()
 
 void TestConvertToInput()
 {
-    BOOST_MESSAGE( "TestConvertToInput");
+    BOOST_WARN_MESSAGE( "TestConvertToInput");
     {
         OutputBuffer ob;
         size_t dataSize = kDefaultBlockSize*2 + kDefaultBlockSize/2;
@@ -277,7 +277,7 @@ void TestConvertToInput()
 
 void TestExtractToInput()
 {
-    BOOST_MESSAGE( "TestExtractToInput");
+    BOOST_WARN_MESSAGE( "TestExtractToInput");
     {
         OutputBuffer ob;
         size_t dataSize = kDefaultBlockSize*2 + kDefaultBlockSize/2;
@@ -376,7 +376,7 @@ void TestExtractToInput()
 
 void TestAppend()
 {
-    BOOST_MESSAGE( "TestAppend");
+    BOOST_WARN_MESSAGE( "TestAppend");
     {
         OutputBuffer ob;
         size_t dataSize = kDefaultBlockSize + kDefaultBlockSize/2;
@@ -405,7 +405,7 @@ void TestAppend()
 
 void TestBufferStream()
 {
-    BOOST_MESSAGE( "TestBufferStream");
+    BOOST_WARN_MESSAGE( "TestBufferStream");
 
     {
         // write enough bytes to a buffer, to create at least 3 blocks
@@ -456,7 +456,7 @@ void TestEof()
 
 void TestBufferStreamEof()
 {
-    BOOST_MESSAGE( "TestBufferStreamEof");
+    BOOST_WARN_MESSAGE( "TestBufferStreamEof");
 
     TestEof<int32_t>();
 
@@ -469,7 +469,7 @@ void TestBufferStreamEof()
 
 void TestSeekAndTell()
 {
-    BOOST_MESSAGE( "TestSeekAndTell");
+    BOOST_WARN_MESSAGE( "TestSeekAndTell");
 
     {
         std::string junk = makeString(kDefaultBlockSize/2);
@@ -501,7 +501,7 @@ void TestSeekAndTell()
 
 void TestReadSome()
 {
-    BOOST_MESSAGE( "TestReadSome");
+    BOOST_WARN_MESSAGE( "TestReadSome");
     {
         std::string junk = makeString(kDefaultBlockSize/2);
 
@@ -531,7 +531,7 @@ void TestReadSome()
 
 void TestSeek()
 {
-    BOOST_MESSAGE( "TestSeek");
+    BOOST_WARN_MESSAGE( "TestSeek");
     {
         const std::string str = "SampleMessage";
 
@@ -592,7 +592,7 @@ void TestSeek()
 
 void TestIterator() 
 {
-    BOOST_MESSAGE( "TestIterator");
+    BOOST_WARN_MESSAGE( "TestIterator");
     {
         OutputBuffer ob(2 * kMaxBlockSize + 10);
         BOOST_CHECK_EQUAL(ob.numChunks(), 3);
@@ -674,7 +674,7 @@ void server(boost::barrier &b)
 void TestAsioBuffer()
 {
     using boost::asio::ip::tcp;
-    BOOST_MESSAGE( "TestAsioBuffer");
+    BOOST_WARN_MESSAGE( "TestAsioBuffer");
     {
         boost::barrier b(2);
 
@@ -746,7 +746,7 @@ void TestAsioBuffer()
 
 void TestSplit()
 {
-    BOOST_MESSAGE( "TestSplit");
+    BOOST_WARN_MESSAGE( "TestSplit");
     {
         const std::string str = "This message is to be split";
 
@@ -773,7 +773,7 @@ void TestSplit()
 
 void TestSplitOnBorder()
 {
-    BOOST_MESSAGE( "TestSplitOnBorder");
+    BOOST_WARN_MESSAGE( "TestSplitOnBorder");
     {
 
         const std::string part1 = "This message";
@@ -812,7 +812,7 @@ void TestSplitOnBorder()
 
 void TestSplitTwice() 
 {
-    BOOST_MESSAGE( "TestSplitTwice");
+    BOOST_WARN_MESSAGE( "TestSplitTwice");
     {
         const std::string msg1 = makeString(30);
 
@@ -842,7 +842,7 @@ void TestSplitTwice()
 
 void TestCopy() 
 {
-    BOOST_MESSAGE( "TestCopy");
+    BOOST_WARN_MESSAGE( "TestCopy");
 
     const std::string msg = makeString(30);
     // Test1, small data, small buffer
@@ -998,7 +998,7 @@ void TestCopy()
 // this is reproducing a sequence of steps that caused a crash
 void TestBug()  
 {
-    BOOST_MESSAGE( "TestBug");
+    BOOST_WARN_MESSAGE( "TestBug");
     {
         OutputBuffer rxBuf;
         OutputBuffer  buf;
@@ -1038,7 +1038,7 @@ void deleteForeign(const std::string &val)
 
 void TestForeign ()  
 {
-    BOOST_MESSAGE( "TestForeign");
+    BOOST_WARN_MESSAGE( "TestForeign");
     {
         std::string hello = "hello ";
         std::string there = "there ";
@@ -1065,7 +1065,7 @@ void TestForeign ()
 
 void TestForeignDiscard ()  
 {
-    BOOST_MESSAGE( "TestForeign");
+    BOOST_WARN_MESSAGE( "TestForeign");
     {
         std::string hello = "hello ";
         std::string again = "again ";
@@ -1104,7 +1104,7 @@ void TestForeignDiscard ()
 
 void TestPrinter()
 {
-    BOOST_MESSAGE( "TestPrinter");
+    BOOST_WARN_MESSAGE( "TestPrinter");
     {
         OutputBuffer ob;
         addDataToBuffer(ob, 128);


### PR DESCRIPTION
This is fixing some things in our fork of apache/avro/lang/c++ - Most of these issues have been fixed in upstream apache/avro in 1.9.x, but to do that move would make some breaking API changes to these libraries. Most of them were on the build side anyways. Summary:

* Add `-fPIC` switch (this was an EL8 build error saying that you should add `-fPIC`) - This was a change taken from upstream: https://github.com/apache/avro/commit/0e6df4837b1032a51e7fd85c95451781991d4856 (no `-std=c++11` as that would break EL6 build as its too old)
* Add `-g` to produce debug symbols - I'm not sure why EL6 or 7 wasn't complaining about this.
* Moved from deprecated boost testing macros to supported one. This was another upstream fix: https://issues.apache.org/jira/browse/AVRO-1719

### Build Testing

I tested these changes in epel-6-x86_64, epel-7-x86_64, and epel-8-x86_64 - They all built:

```
Requires(rpmlib): rpmlib(CompressedFileNames) <= 3.0.4-1 rpmlib(FileDigests) <= 4.6.0-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1
Recommends: avro-cpp-debugsource(x86-64) = 1.8.0-1.el8
Checking for unpackaged file(s): /usr/lib/rpm/check-files /builddir/build/BUILDROOT/avro-cpp-1.8.0-1.el8.x86_64
Wrote: /builddir/build/RPMS/avro-cpp-1.8.0-1.el8.x86_64.rpm
Wrote: /builddir/build/RPMS/avro-cpp-devel-1.8.0-1.el8.x86_64.rpm
Wrote: /builddir/build/RPMS/avro-cpp-debugsource-1.8.0-1.el8.x86_64.rpm
Wrote: /builddir/build/RPMS/avro-cpp-debuginfo-1.8.0-1.el8.x86_64.rpm
Wrote: /builddir/build/RPMS/avro-cpp-devel-debuginfo-1.8.0-1.el8.x86_64.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.H2RovV
+ umask 022
+ cd /builddir/build/BUILD
+ cd avro-cpp-1.8.0
+ rm -rf /builddir/build/BUILDROOT/avro-cpp-1.8.0-1.el8.x86_64
+ exit 0
Finish: rpmbuild avro-cpp-1.8.0-1.el8.src.rpm
Finish: build phase for avro-cpp-1.8.0-1.el8.src.rpm
INFO: Done(pkgs-1.8.0-1-epel-8-x86_64/avro-cpp-1.8.0-1.el8.src.rpm) Config(epel-8-x86_64) 2 minutes 16 seconds
INFO: Results and/or logs in: pkgs-1.8.0-1-epel-8-x86_64
Finish: run
======= Binary RPMs now available in pkgs-1.8.0-1-epel-8-x86_64 =======
```

```
Processing files: avro-cpp-debuginfo-1.8.0-1.el7.x86_64
Provides: avro-cpp-debuginfo = 1.8.0-1.el7 avro-cpp-debuginfo(x86-64) = 1.8.0-1.el7
Requires(rpmlib): rpmlib(FileDigests) <= 4.6.0-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1 rpmlib(CompressedFileNames) <= 3.0.4-1
Checking for unpackaged file(s): /usr/lib/rpm/check-files /builddir/build/BUILDROOT/avro-cpp-1.8.0-1.el7.x86_64
Wrote: /builddir/build/RPMS/avro-cpp-1.8.0-1.el7.x86_64.rpm
Wrote: /builddir/build/RPMS/avro-cpp-devel-1.8.0-1.el7.x86_64.rpm
Wrote: /builddir/build/RPMS/avro-cpp-debuginfo-1.8.0-1.el7.x86_64.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.KRyjHP
+ umask 022
+ cd /builddir/build/BUILD
+ cd avro-cpp-1.8.0
+ rm -rf /builddir/build/BUILDROOT/avro-cpp-1.8.0-1.el7.x86_64
+ exit 0
Finish: rpmbuild avro-cpp-1.8.0-1.el7.src.rpm
Finish: build phase for avro-cpp-1.8.0-1.el7.src.rpm
INFO: Done(pkgs-1.8.0-1-epel-7-x86_64/avro-cpp-1.8.0-1.el7.src.rpm) Config(epel-7-x86_64) 1 minutes 30 seconds
INFO: Results and/or logs in: pkgs-1.8.0-1-epel-7-x86_64
Finish: run
======= Binary RPMs now available in pkgs-1.8.0-1-epel-7-x86_64 =======
```

```
Checking for unpackaged file(s): /usr/lib/rpm/check-files /builddir/build/BUILDROOT/avro-cpp-1.8.0-1.el6.x86_64
warning: Could not canonicalize hostname: ip-172-31-35-84.us-west-2.compute.internal
Wrote: /builddir/build/RPMS/avro-cpp-1.8.0-1.el6.x86_64.rpm
Wrote: /builddir/build/RPMS/avro-cpp-devel-1.8.0-1.el6.x86_64.rpm
Wrote: /builddir/build/RPMS/avro-cpp-debuginfo-1.8.0-1.el6.x86_64.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.hiS8to
+ umask 022
+ cd /builddir/build/BUILD
+ cd avro-cpp-1.8.0
+ rm -rf /builddir/build/BUILDROOT/avro-cpp-1.8.0-1.el6.x86_64
+ exit 0
Finish: rpmbuild avro-cpp-1.8.0-1.el6.src.rpm
Finish: build phase for avro-cpp-1.8.0-1.el6.src.rpm
INFO: Done(pkgs-1.8.0-1-epel-6-x86_64/avro-cpp-1.8.0-1.el6.src.rpm) Config(epel-6-x86_64) 2 minutes 11 seconds
INFO: Results and/or logs in: pkgs-1.8.0-1-epel-6-x86_64
Finish: run
======= Binary RPMs now available in pkgs-1.8.0-1-epel-6-x86_64 =======
```