### PR TITLE
Collapse rpm branch into master

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,8 @@ add_definitions (
     -DBOOST_IOSTREAMS_DYN_LINK
     -DBOOST_PROGRAM_OPTIONS_DYN_LINK
     -DBOOST_ALL_NO_LIB)
+else()
+    add_definitions(-fPIC -g -O2)
 endif()
 
 if (CMAKE_COMPILER_IS_GNUCXX)

--- a/SOURCES/0001-rpm-cmake-install-dirs.patch
+++ b/SOURCES/0001-rpm-cmake-install-dirs.patch
@@ -1,0 +1,1 @@
+../rpm/0001-rpm-cmake-install-dirs.patch

--- a/debian/rules
+++ b/debian/rules
@@ -21,11 +21,10 @@ include /usr/share/dpkg/default.mk
 %:
 	dh $@ 
 
-# dh_make generated override targets
-# This is example for Cmake (See https://bugs.debian.org/641051 )
-#override_dh_auto_configure:
-#	dh_auto_configure -- \
-#	-DCMAKE_LIBRARY_PATH=$(DEB_HOST_MULTIARCH)
+# Debian 9 and Ubuntu18 cmakes need to have CMAKE_INSTALL_LIBDIR defined to lib/$(DEB_HOST_MULTIARCH).
+# For whatever reason, CMake on these versions arent determining that this is what we want.
+override_dh_auto_configure:
+	dh_auto_configure -- -DCMAKE_INSTALL_LIBDIR=lib/$(DEB_HOST_MULTIARCH)
 
 
 

--- a/rpm/.gitignore
+++ b/rpm/.gitignore
@@ -1,0 +1,2 @@
+pkgs-*
+SOURCES

--- a/rpm/0001-rpm-cmake-install-dirs.patch
+++ b/rpm/0001-rpm-cmake-install-dirs.patch
@@ -1,0 +1,21 @@
+diff --git CMakeLists.txt CMakeLists.txt
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -155,13 +155,13 @@ set (CPACK_PACKAGE_FILE_NAME "avrocpp-${AVRO_VERSION_MAJOR}")
+ include (CPack)
+ 
+ install (TARGETS avrocpp avrocpp_s
+-    LIBRARY DESTINATION lib
+-    ARCHIVE DESTINATION lib
+-    RUNTIME DESTINATION lib)
++    LIBRARY DESTINATION "${LIB_INSTALL_DIR}"
++    ARCHIVE DESTINATION "${LIB_INSTALL_DIR}"
++    RUNTIME DESTINATION "${LIB_INSTALL_DIR}")
+ 
+ install (TARGETS avrogencpp RUNTIME DESTINATION bin)
+ 
+-install (DIRECTORY api/ DESTINATION include/avro
++install (DIRECTORY api/ DESTINATION "${INCLUDE_INSTALL_DIR}/avro"
+     FILES_MATCHING PATTERN *.hh)
+ 
+ if (NOT CMAKE_BUILD_TYPE)

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -28,6 +28,7 @@ build_prepare: archive
 
 srpm: build_prepare
 	/usr/bin/mock \
+		$(MOCK_OPTIONS) \
 		--no-cleanup-after \
 		-r $(MOCK_CONFIG) \
 		--define "__version $(VERSION)$(VERSION_SUFFIX)" \
@@ -40,6 +41,7 @@ srpm: build_prepare
 
 rpm: srpm
 	/usr/bin/mock \
+		$(MOCK_OPTIONS) \
 		--no-cleanup-after \
 		-r $(MOCK_CONFIG) \
 		--define "__version $(VERSION)$(VERSION_SUFFIX)"\

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -1,0 +1,55 @@
+PACKAGE_NAME?=	avro-cpp
+VERSION?=	1.8.0
+
+BUILD_NUMBER?= 1
+
+MOCK_CONFIG?=default
+
+RESULT_DIR?=pkgs-$(VERSION)-$(BUILD_NUMBER)-$(MOCK_CONFIG)
+
+all: rpm
+
+
+SOURCES:
+	mkdir -p SOURCES
+
+archive: SOURCES
+	cd ../ && \
+	git archive --prefix=$(PACKAGE_NAME)-$(VERSION)/ \
+	  -o rpm/SOURCES/$(PACKAGE_NAME)-$(VERSION).tar.gz HEAD
+
+
+build_prepare: archive
+	cp *.patch SOURCES
+	mkdir -p $(RESULT_DIR)
+	rm -f $(RESULT_DIR)/$(PACKAGE_NAME)*.rpm
+
+
+srpm: build_prepare
+	/usr/bin/mock \
+		--no-cleanup-after \
+		-r $(MOCK_CONFIG) \
+		--define "__version $(VERSION)" \
+		--define "__release $(BUILD_NUMBER)" \
+		--resultdir=$(RESULT_DIR) \
+		--buildsrpm \
+		--spec=$(PACKAGE_NAME).spec \
+		--sources=SOURCES
+	@echo "======= Source RPM now available in $(RESULT_DIR) ======="
+
+rpm: srpm
+	/usr/bin/mock \
+		--no-cleanup-after \
+		-r $(MOCK_CONFIG) \
+		--define "__version $(VERSION)"\
+		--define "__release $(BUILD_NUMBER)"\
+		--resultdir=$(RESULT_DIR) \
+		--rebuild $(RESULT_DIR)/$(PACKAGE_NAME)*.src.rpm
+	@echo "======= Binary RPMs now available in $(RESULT_DIR) ======="
+
+clean:
+	rm -rf SOURCES
+
+distclean: clean
+	rm -f build.log root.log state.log available_pkgs installed_pkgs \
+		*.rpm *.tar.gz

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -1,11 +1,12 @@
 PACKAGE_NAME?=	avro-cpp
 VERSION?=	1.8.0
+VERSION_SUFFIX?=
 
 BUILD_NUMBER?= 1
 
 MOCK_CONFIG?=default
 
-RESULT_DIR?=pkgs-$(VERSION)-$(BUILD_NUMBER)-$(MOCK_CONFIG)
+RESULT_DIR?=pkgs-$(VERSION)$(VERSION_SUFFIX)-$(BUILD_NUMBER)-$(MOCK_CONFIG)
 
 all: rpm
 
@@ -15,8 +16,8 @@ SOURCES:
 
 archive: SOURCES
 	cd ../ && \
-	git archive --prefix=$(PACKAGE_NAME)-$(VERSION)/ \
-	  -o rpm/SOURCES/$(PACKAGE_NAME)-$(VERSION).tar.gz HEAD
+	git archive --prefix=$(PACKAGE_NAME)-$(VERSION)$(VERSION_SUFFIX)/ \
+	  -o rpm/SOURCES/$(PACKAGE_NAME)-$(VERSION)$(VERSION_SUFFIX).tar.gz HEAD
 
 
 build_prepare: archive
@@ -29,7 +30,7 @@ srpm: build_prepare
 	/usr/bin/mock \
 		--no-cleanup-after \
 		-r $(MOCK_CONFIG) \
-		--define "__version $(VERSION)" \
+		--define "__version $(VERSION)$(VERSION_SUFFIX)" \
 		--define "__release $(BUILD_NUMBER)" \
 		--resultdir=$(RESULT_DIR) \
 		--buildsrpm \
@@ -41,7 +42,7 @@ rpm: srpm
 	/usr/bin/mock \
 		--no-cleanup-after \
 		-r $(MOCK_CONFIG) \
-		--define "__version $(VERSION)"\
+		--define "__version $(VERSION)$(VERSION_SUFFIX)"\
 		--define "__release $(BUILD_NUMBER)"\
 		--resultdir=$(RESULT_DIR) \
 		--rebuild $(RESULT_DIR)/$(PACKAGE_NAME)*.src.rpm

--- a/rpm/README
+++ b/rpm/README
@@ -1,0 +1,11 @@
+
+Build RPM packages
+==================
+
+Requires: mock
+
+
+Build:
+
+   MOCK_CONFIG=fedora-20-x86_64 make
+

--- a/rpm/README
+++ b/rpm/README
@@ -9,3 +9,8 @@ Build:
 
    MOCK_CONFIG=fedora-20-x86_64 make
 
+Additional Mock Options:
+
+    # Say you wanted to build an RPM targeting a distro with rpm>4.12.x with rpm<4.12.x
+    MOCK_OPTIONS=--bootstrap-chroot MOCK_CONFIG=fedora-30-x86_64 make
+

--- a/rpm/avro-cpp.spec
+++ b/rpm/avro-cpp.spec
@@ -11,6 +11,7 @@ Source:	 avro-cpp-%{version}.tar.gz
 Patch0: 0001-rpm-cmake-install-dirs.patch
 
 BuildRequires: cmake jansson-devel boost-devel
+Requires: boost-devel
 BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 
 %description

--- a/rpm/avro-cpp.spec
+++ b/rpm/avro-cpp.spec
@@ -1,0 +1,83 @@
+Name:    avro-cpp
+Version: %{__version}
+Release: %{__release}%{?dist}
+
+Summary: Apache Avro data serialization C++ library
+Group:   Development/Libraries/C and C++
+License: ASL 2.0
+URL:     http://avro.apache.org
+Source:	 avro-cpp-%{version}.tar.gz
+
+Patch0: 0001-rpm-cmake-install-dirs.patch
+
+BuildRequires: cmake jansson-devel boost-devel
+BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+
+%description
+Apache Avro™ is a data serialization system.
+Avro provides:
+ * Rich data structures.
+ * A compact, fast, binary data format.
+ * A container file, to store persistent data.
+ * Remote procedure call (RPC).
+ * Simple integration with dynamic languages.
+
+%package devel
+Summary: Apache Avro data serialization C++ library (Development Environment)
+Group:   Development/Libraries/C and C++
+Requires: %{name} = %{version}
+
+%description devel
+Apache Avro™ is a data serialization system.
+Avro provides:
+ * Rich data structures.
+ * A compact, fast, binary data format.
+ * A container file, to store persistent data.
+ * Remote procedure call (RPC).
+ * Simple integration with dynamic languages.
+
+This package contains headers and libraries required to build applications
+using avro-cpp.
+
+
+
+
+%prep
+%setup -q -n %{name}-%{version}
+
+%patch0
+
+%build
+%cmake . -DCMAKE_INSTALL_PREFIX=/usr
+make %{?_smp_mflags}
+
+%install
+rm -rf %{buildroot}
+DESTDIR=%{buildroot} make install
+
+%clean
+rm -rf %{buildroot}
+
+%post   -p /sbin/ldconfig
+%postun -p /sbin/ldconfig
+
+%files
+%defattr(444,root,root)
+%{_libdir}/libavrocpp.so.*
+%defattr(-,root,root)
+%doc LICENSE
+
+
+%files devel
+%defattr(-,root,root)
+%{_includedir}/avro
+%defattr(444,root,root)
+%{_libdir}/libavrocpp_s.a
+%{_libdir}/libavrocpp.so
+%{_bindir}/avrogencpp
+%doc LICENSE
+
+
+%changelog
+* Mon May 16 2016 Magnus Edenhill <magnus@confluent.io> 1.8.0-0
+- Initial RPM

--- a/test/CodecTests.cc
+++ b/test/CodecTests.cc
@@ -1342,9 +1342,18 @@ static const TestData4 data4[] = {
 #define COUNTOF(x)  sizeof(x) / sizeof(x[0])
 #define ENDOF(x)    (x) + COUNTOF(x)
 
-#define ADD_TESTS(testSuite, Factory, testFunc, data)           \
-testSuite.add(BOOST_PARAM_TEST_CASE(&testFunc<Factory>,         \
-    data, data + COUNTOF(data)))
+// Boost 1.67 and later expects test cases to have unique names. This dummy
+// helper functions leads to names which compose 'testFunc', 'Factory', and
+// 'data'.
+template <typename Test, typename Data>
+Test testWithData(const Test &test, const Data &data) {
+    // This wasn't around until boost-1.53.0
+    // boost::ignore_unused(data);
+    return test;
+}
+#define ADD_TESTS(testSuite, Factory, testFunc, data) \
+    testSuite.add(BOOST_PARAM_TEST_CASE(              \
+        testWithData(&testFunc<Factory>, data), data, data + COUNTOF(data)))
 
 struct BinaryEncoderFactory {
     static EncoderPtr newEncoder(const ValidSchema& schema) {

--- a/test/DataFileTests.cc
+++ b/test/DataFileTests.cc
@@ -465,37 +465,64 @@ void addReaderTests(test_suite* ts, const shared_ptr<DataFileTest>& t)
 test_suite*
 init_unit_test_suite( int argc, char* argv[] )
 {
-    test_suite* ts= BOOST_TEST_SUITE("DataFile tests");
-    shared_ptr<DataFileTest> t1(new DataFileTest("test1.df", sch, isch));
-    ts->add(BOOST_CLASS_TEST_CASE(&DataFileTest::testWrite, t1));
-    addReaderTests(ts, t1);
-
-    shared_ptr<DataFileTest> t2(new DataFileTest("test2.df", sch, isch));
-    ts->add(BOOST_CLASS_TEST_CASE(&DataFileTest::testWriteGeneric, t2));
-    addReaderTests(ts, t2);
-
-    shared_ptr<DataFileTest> t3(new DataFileTest("test3.df", dsch, dblsch));
-    ts->add(BOOST_CLASS_TEST_CASE(&DataFileTest::testWriteDouble, t3));
-    ts->add(BOOST_CLASS_TEST_CASE(&DataFileTest::testReadDouble, t3));
-    ts->add(BOOST_CLASS_TEST_CASE(&DataFileTest::testReadDoubleTwoStep, t3));
-    ts->add(BOOST_CLASS_TEST_CASE(&DataFileTest::testReadDoubleTwoStepProject,
-        t3));
-    ts->add(BOOST_CLASS_TEST_CASE(&DataFileTest::testCleanup, t3));
-
-    shared_ptr<DataFileTest> t4(new DataFileTest("test4.df", dsch, dblsch));
-    ts->add(BOOST_CLASS_TEST_CASE(&DataFileTest::testTruncate, t4));
-    ts->add(BOOST_CLASS_TEST_CASE(&DataFileTest::testCleanup, t4));
-
-    shared_ptr<DataFileTest> t5(new DataFileTest("test5.df", sch, isch));
-    ts->add(BOOST_CLASS_TEST_CASE(&DataFileTest::testWriteGenericByName, t5));
-    addReaderTests(ts, t5);
-
-    shared_ptr<DataFileTest> t6(new DataFileTest("test6.df", dsch, dblsch));
-    ts->add(BOOST_CLASS_TEST_CASE(&DataFileTest::testZip, t6));
-
-    shared_ptr<DataFileTest> t7(new DataFileTest("test7.df",fsch,fsch));
-    ts->add(BOOST_CLASS_TEST_CASE(&DataFileTest::testSchemaReadWrite,t7));
-    ts->add(BOOST_CLASS_TEST_CASE(&DataFileTest::testCleanup,t7));
-
-    return ts;
+    {
+        test_suite *ts = BOOST_TEST_SUITE("DataFile tests: test1.df");
+        shared_ptr<DataFileTest> t1(new DataFileTest("test1.df", sch, isch));
+        ts->add(BOOST_CLASS_TEST_CASE(&DataFileTest::testWrite, t1));
+        addReaderTests(ts, t1);
+        boost::unit_test::framework::master_test_suite().add(ts);
+    }
+    {
+        test_suite *ts = BOOST_TEST_SUITE("DataFile tests: test2.df");
+        shared_ptr<DataFileTest> t2(new DataFileTest("test2.df", sch, isch));
+        ts->add(BOOST_CLASS_TEST_CASE(&DataFileTest::testWriteGeneric, t2));
+        addReaderTests(ts, t2);
+        boost::unit_test::framework::master_test_suite().add(ts);
+    }
+    {
+        test_suite *ts = BOOST_TEST_SUITE("DataFile tests: test3.df");
+        shared_ptr<DataFileTest> t3(new DataFileTest("test3.df", dsch, dblsch));
+        ts->add(BOOST_CLASS_TEST_CASE(&DataFileTest::testWriteDouble, t3));
+        ts->add(BOOST_CLASS_TEST_CASE(&DataFileTest::testReadDouble, t3));
+        ts->add(
+            BOOST_CLASS_TEST_CASE(&DataFileTest::testReadDoubleTwoStep, t3));
+        ts->add(BOOST_CLASS_TEST_CASE(
+            &DataFileTest::testReadDoubleTwoStepProject, t3));
+        ts->add(BOOST_CLASS_TEST_CASE(&DataFileTest::testCleanup, t3));
+        boost::unit_test::framework::master_test_suite().add(ts);
+    }
+    {
+        test_suite *ts = BOOST_TEST_SUITE("DataFile tests: test4.df");
+        shared_ptr<DataFileTest> t4(new DataFileTest("test4.df", dsch, dblsch));
+        ts->add(BOOST_CLASS_TEST_CASE(&DataFileTest::testTruncate, t4));
+        ts->add(BOOST_CLASS_TEST_CASE(&DataFileTest::testCleanup, t4));
+        boost::unit_test::framework::master_test_suite().add(ts);
+    }
+    {
+        test_suite *ts = BOOST_TEST_SUITE("DataFile tests: test5.df");
+        shared_ptr<DataFileTest> t5(new DataFileTest("test5.df", sch, isch));
+        ts->add(
+            BOOST_CLASS_TEST_CASE(&DataFileTest::testWriteGenericByName, t5));
+        addReaderTests(ts, t5);
+        boost::unit_test::framework::master_test_suite().add(ts);
+    }
+    {
+        test_suite *ts = BOOST_TEST_SUITE("DataFile tests: test6.df");
+        shared_ptr<DataFileTest> t6(new DataFileTest("test6.df", dsch, dblsch));
+        ts->add(BOOST_CLASS_TEST_CASE(&DataFileTest::testZip, t6));
+        boost::unit_test::framework::master_test_suite().add(ts);
+    }
+    {
+        test_suite *ts = BOOST_TEST_SUITE("DataFile tests: test8.df");
+        shared_ptr<DataFileTest> t8(new DataFileTest("test8.df", dsch, dblsch));
+        boost::unit_test::framework::master_test_suite().add(ts);
+    }
+    {
+        test_suite *ts = BOOST_TEST_SUITE("DataFile tests: test7.df");
+        shared_ptr<DataFileTest> t7(new DataFileTest("test7.df", fsch, fsch));
+        ts->add(BOOST_CLASS_TEST_CASE(&DataFileTest::testSchemaReadWrite, t7));
+        ts->add(BOOST_CLASS_TEST_CASE(&DataFileTest::testCleanup, t7));
+        boost::unit_test::framework::master_test_suite().add(ts);
+    }
+    return 0;
 }

--- a/test/SchemaTests.cc
+++ b/test/SchemaTests.cc
@@ -138,19 +138,19 @@ const char* basicSchemaErrors[] = {
 
 static void testBasic(const char* schema)
 {
-    BOOST_CHECKPOINT(schema);
+    BOOST_TEST_CHECKPOINT(schema);
     compileJsonSchemaFromString(schema);
 }
 
 static void testBasic_fail(const char* schema)
 {
-    BOOST_CHECKPOINT(schema);
+    BOOST_TEST_CHECKPOINT(schema);
     BOOST_CHECK_THROW(compileJsonSchemaFromString(schema), Exception);
 }
 
 static void testCompile(const char* schema)
 {
-    BOOST_CHECKPOINT(schema);
+    BOOST_TEST_CHECKPOINT(schema);
     compileJsonSchemaFromString(std::string(schema));
 }
 

--- a/test/buffertest.cc
+++ b/test/buffertest.cc
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -64,7 +64,7 @@ void printBuffer(const InputBuffer &buf)
 
 void TestReserve()
 {
-    BOOST_MESSAGE( "TestReserve");
+    BOOST_TEST_MESSAGE( "TestReserve");
     {
         OutputBuffer ob;
         BOOST_CHECK_EQUAL(ob.size(), 0U);
@@ -111,7 +111,7 @@ void addDataToBuffer(OutputBuffer &buf, size_t size)
 
 void TestGrow()
 {
-    BOOST_MESSAGE( "TestGrow");
+    BOOST_TEST_MESSAGE( "TestGrow");
     { 
         OutputBuffer ob;
 
@@ -151,7 +151,7 @@ void TestGrow()
 
 void TestDiscard()
 {
-    BOOST_MESSAGE( "TestDiscard");
+    BOOST_TEST_MESSAGE( "TestDiscard");
     {
         OutputBuffer ob;
         size_t dataSize = kDefaultBlockSize*2 + kDefaultBlockSize/2;
@@ -257,7 +257,7 @@ void TestDiscard()
 
 void TestConvertToInput()
 {
-    BOOST_MESSAGE( "TestConvertToInput");
+    BOOST_TEST_MESSAGE( "TestConvertToInput");
     {
         OutputBuffer ob;
         size_t dataSize = kDefaultBlockSize*2 + kDefaultBlockSize/2;
@@ -277,7 +277,7 @@ void TestConvertToInput()
 
 void TestExtractToInput()
 {
-    BOOST_MESSAGE( "TestExtractToInput");
+    BOOST_TEST_MESSAGE( "TestExtractToInput");
     {
         OutputBuffer ob;
         size_t dataSize = kDefaultBlockSize*2 + kDefaultBlockSize/2;
@@ -376,7 +376,7 @@ void TestExtractToInput()
 
 void TestAppend()
 {
-    BOOST_MESSAGE( "TestAppend");
+    BOOST_TEST_MESSAGE( "TestAppend");
     {
         OutputBuffer ob;
         size_t dataSize = kDefaultBlockSize + kDefaultBlockSize/2;
@@ -405,7 +405,7 @@ void TestAppend()
 
 void TestBufferStream()
 {
-    BOOST_MESSAGE( "TestBufferStream");
+    BOOST_TEST_MESSAGE( "TestBufferStream");
 
     {
         // write enough bytes to a buffer, to create at least 3 blocks
@@ -456,7 +456,7 @@ void TestEof()
 
 void TestBufferStreamEof()
 {
-    BOOST_MESSAGE( "TestBufferStreamEof");
+    BOOST_TEST_MESSAGE( "TestBufferStreamEof");
 
     TestEof<int32_t>();
 
@@ -469,7 +469,7 @@ void TestBufferStreamEof()
 
 void TestSeekAndTell()
 {
-    BOOST_MESSAGE( "TestSeekAndTell");
+    BOOST_TEST_MESSAGE( "TestSeekAndTell");
 
     {
         std::string junk = makeString(kDefaultBlockSize/2);
@@ -501,7 +501,7 @@ void TestSeekAndTell()
 
 void TestReadSome()
 {
-    BOOST_MESSAGE( "TestReadSome");
+    BOOST_TEST_MESSAGE( "TestReadSome");
     {
         std::string junk = makeString(kDefaultBlockSize/2);
 
@@ -531,7 +531,7 @@ void TestReadSome()
 
 void TestSeek()
 {
-    BOOST_MESSAGE( "TestSeek");
+    BOOST_TEST_MESSAGE( "TestSeek");
     {
         const std::string str = "SampleMessage";
 
@@ -592,7 +592,7 @@ void TestSeek()
 
 void TestIterator() 
 {
-    BOOST_MESSAGE( "TestIterator");
+    BOOST_TEST_MESSAGE( "TestIterator");
     {
         OutputBuffer ob(2 * kMaxBlockSize + 10);
         BOOST_CHECK_EQUAL(ob.numChunks(), 3);
@@ -674,7 +674,7 @@ void server(boost::barrier &b)
 void TestAsioBuffer()
 {
     using boost::asio::ip::tcp;
-    BOOST_MESSAGE( "TestAsioBuffer");
+    BOOST_TEST_MESSAGE( "TestAsioBuffer");
     {
         boost::barrier b(2);
 
@@ -746,7 +746,7 @@ void TestAsioBuffer()
 
 void TestSplit()
 {
-    BOOST_MESSAGE( "TestSplit");
+    BOOST_TEST_MESSAGE( "TestSplit");
     {
         const std::string str = "This message is to be split";
 
@@ -773,7 +773,7 @@ void TestSplit()
 
 void TestSplitOnBorder()
 {
-    BOOST_MESSAGE( "TestSplitOnBorder");
+    BOOST_TEST_MESSAGE( "TestSplitOnBorder");
     {
 
         const std::string part1 = "This message";
@@ -812,7 +812,7 @@ void TestSplitOnBorder()
 
 void TestSplitTwice() 
 {
-    BOOST_MESSAGE( "TestSplitTwice");
+    BOOST_TEST_MESSAGE( "TestSplitTwice");
     {
         const std::string msg1 = makeString(30);
 
@@ -842,7 +842,7 @@ void TestSplitTwice()
 
 void TestCopy() 
 {
-    BOOST_MESSAGE( "TestCopy");
+    BOOST_TEST_MESSAGE( "TestCopy");
 
     const std::string msg = makeString(30);
     // Test1, small data, small buffer
@@ -998,7 +998,7 @@ void TestCopy()
 // this is reproducing a sequence of steps that caused a crash
 void TestBug()  
 {
-    BOOST_MESSAGE( "TestBug");
+    BOOST_TEST_MESSAGE( "TestBug");
     {
         OutputBuffer rxBuf;
         OutputBuffer  buf;
@@ -1038,7 +1038,7 @@ void deleteForeign(const std::string &val)
 
 void TestForeign ()  
 {
-    BOOST_MESSAGE( "TestForeign");
+    BOOST_TEST_MESSAGE( "TestForeign");
     {
         std::string hello = "hello ";
         std::string there = "there ";
@@ -1065,7 +1065,7 @@ void TestForeign ()
 
 void TestForeignDiscard ()  
 {
-    BOOST_MESSAGE( "TestForeign");
+    BOOST_TEST_MESSAGE( "TestForeign");
     {
         std::string hello = "hello ";
         std::string again = "again ";
@@ -1104,7 +1104,7 @@ void TestForeignDiscard ()
 
 void TestPrinter()
 {
-    BOOST_MESSAGE( "TestPrinter");
+    BOOST_TEST_MESSAGE( "TestPrinter");
     {
         OutputBuffer ob;
         addDataToBuffer(ob, 128);

--- a/test/unittest.cc
+++ b/test/unittest.cc
@@ -20,6 +20,7 @@
 #include <fstream>
 #include <sstream>
 #include <boost/test/included/unit_test_framework.hpp>
+#include <boost/make_shared.hpp>
 
 #include "Zigzag.hh"
 #include "Node.hh"
@@ -767,14 +768,6 @@ struct TestResolution
     ValidSchema unionTwo_;
 };
 
-
-template<typename T>
-void addTestCase(boost::unit_test::test_suite &test) 
-{
-    boost::shared_ptr<T> newtest( new T );
-    test.add( BOOST_CLASS_TEST_CASE( &T::test, newtest ));
-}
-
 boost::unit_test::test_suite*
 init_unit_test_suite( int argc, char* argv[] ) 
 {
@@ -782,12 +775,18 @@ init_unit_test_suite( int argc, char* argv[] )
 
     test_suite* test= BOOST_TEST_SUITE( "Avro C++ unit test suite" );
 
-    addTestCase<TestEncoding>(*test);
-    addTestCase<TestSchema>(*test);
-    addTestCase<TestNested>(*test);
-    addTestCase<TestGenerated>(*test);
-    addTestCase<TestBadStuff>(*test);
-    addTestCase<TestResolution>(*test);
+    test->add(BOOST_CLASS_TEST_CASE(&TestEncoding::test,
+                                    boost::make_shared<TestEncoding>()));
+    test->add(BOOST_CLASS_TEST_CASE(&TestSchema::test,
+                                    boost::make_shared<TestSchema>()));
+    test->add(BOOST_CLASS_TEST_CASE(&TestNested::test,
+                                    boost::make_shared<TestNested>()));
+    test->add(BOOST_CLASS_TEST_CASE(&TestGenerated::test,
+                                    boost::make_shared<TestGenerated>()));
+    test->add(BOOST_CLASS_TEST_CASE(&TestBadStuff::test,
+                                    boost::make_shared<TestBadStuff>()));
+    test->add(BOOST_CLASS_TEST_CASE(&TestResolution::test,
+                                    boost::make_shared<TestResolution>()));
 
     return test;
 }


### PR DESCRIPTION
Purpose: Confluent Clinets Eng Independent Release Builder/Job

Changes:
* Collapse rpm branch into master
* Symlink SOURCES/0001-rpm-cmake-install-dirs.patch so RPM can find its patches
* Partial backport of https://github.com/apache/avro/commit/67204b83ddbce6d62f48fdf9dbe073f0b9f3abf1 to make these tests work with newer boost testing libraries.
* Override override_dh_auto_configure to set `-DCMAKE_INSTALL_LIBDIR=lib/$(DEB_HOST_MULTIARCH)` for Debian 9 and Ubuntu18

Testing these changes in packaging here:
* https://github.com/confluentinc/packaging/pull/930
* https://github.com/confluentinc/packaging/pull/931